### PR TITLE
LIBFCREPO-1355. Property form validation and display fixes

### DIFF
--- a/src/vocabs/templates/vocabs/new_property.html
+++ b/src/vocabs/templates/vocabs/new_property.html
@@ -1,7 +1,11 @@
 <li class="property">
   <form method="post" action="{% url 'new_property' %}">
     {% csrf_token %}
-    {{ form.term }} {{ form.predicate }} {{ form.value }}
+    {{ form.term }} {{ form.predicate }}
+    <fieldset>
+      {{ form.value }}
+      {{ form.value.errors }}
+    </fieldset>
     <button class="update" hx-post="{% url 'new_property' %}" hx-target="closest .property" type="submit">Save</button>
     <button onclick="this.parentNode.parentNode.remove()">Cancel</button>
   </form>


### PR DESCRIPTION
* Updated new property form to display validation errors, following the pattern in the "src/vocabs/templates/vocabs/property_form.html"

https://umd-dit.atlassian.net/browse/LIBFCREPO-1355