### PR TITLE
LIBFCREPO-1351. Suppress term addition URL in browser history

### DIFF
--- a/src/vocabs/templates/vocabs/vocabulary_detail.html
+++ b/src/vocabs/templates/vocabs/vocabulary_detail.html
@@ -51,7 +51,8 @@
 
   <details id="new-terms" open>
     <summary><h2>Create New Term</h2></summary>
-    <form method="post" action="{% url 'list_terms' pk=vocabulary.id %}" hx-boost="true" hx-target="#terms tbody" hx-swap="beforeend">
+    <form method="post" action="{% url 'list_terms' pk=vocabulary.id %}"
+          hx-boost="true" hx-target="#terms tbody" hx-swap="beforeend" hx-push-url="false">
       {% csrf_token %}
       <input name="term_name" placeholder="Name" required/>
       <select name="rdf_type">


### PR DESCRIPTION
Added `hx-push-url="false"` to the "Create New Term" form, so that the "/vocabs/<vocab id>/terms" endpoint used to add the term, and which only accepts POST requests, would not be included in the browser history, or displayed in the browser address bar.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1351