### PR TITLE
LIBFCREPO-1359. Prevent HX-Trigger events from being overwritten

### DIFF
--- a/src/vocabs/views.py
+++ b/src/vocabs/views.py
@@ -30,7 +30,7 @@ class PublishUpdatesMixin(View):
     def dispatch(self, request, *args, **kwargs):
         response = super().dispatch(request, *args, **kwargs)
 
-        if self.vocabulary_has_updated():
+        if self.vocabulary_has_updated() and ('HX-Trigger' not in response.headers.keys()):
             response.headers['HX-Trigger'] = 'grove:vocabUpdated'
 
         return response
@@ -364,7 +364,8 @@ class NewTermFormView(LoginRequiredMixin, PublishUpdatesMixin, DetailView, FormV
 
         if self.request.htmx:
             response = render(self.request, 'vocabs/term.html', {'term': term, 'predicates': Predicate.objects.all})
-            response.headers['HX-Trigger'] = 'grove:termAdded'
+            if 'HX-Trigger' not in response.headers.keys():
+                response.headers['HX-Trigger'] = 'grove:termAdded'
             return response
         else:
             return HttpResponseRedirect(reverse('show_vocabulary', args=(form.cleaned_data['vocabulary'].id,)))


### PR DESCRIPTION
Fix an issue where the "grove:vocabUpdated" event was overwriting the "grove:termAdded" event in the "HX-Trigger" response header. This was leading to the "Term" form not being replaced with an empty form when a new term is added.

This fix, which may not be optimal, or scale for additional events, essentially sequences the "grove:termAdded" and "grove:vocabUpdated" events, so only one is processed at a time. When a new Term is added this results in one POST (the term submission), and two GET events (the new Term form request, and the vocab updated request.

It is possible to add multiple events to the HX-Trigger handler (see the "Multiple Triggers" section in https://htmx.org/headers/hx-trigger/), but in that case there are three GET requests (beyond the initial POST):

* A GET for the "grove:vocabUpdated" event
* A GET for the "grove:termAdded" event, with a second GET request from the "PublishUpdatesMixin" dispatch method because the vocabulary is still updated.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1359